### PR TITLE
[FIX] update partner if partner_event didn't create it

### DIFF
--- a/website_event_attendee_fields/README.rst
+++ b/website_event_attendee_fields/README.rst
@@ -31,6 +31,8 @@ Also,
 
   * always updates Registration's name and phone to corresponded values of Attendee Partner, because they may be taken from Partner record (e.g. Public User)
 
+  * If attendee partner exists: update new fields
+
 Demo mode
 ---------
 In demo installation:

--- a/website_event_attendee_fields/models/event_registration.py
+++ b/website_event_attendee_fields/models/event_registration.py
@@ -28,9 +28,17 @@ class EventRegistration(models.Model):
             res.name = res.attendee_partner_id.name
             res.phone = res.attendee_partner_id.phone
 
-            if partner_exists and res.attendee_partner_id == self.env.user.partner_id:
-                res.attendee_partner_id.sudo().write(
-                    self._prepare_partner(vals))
+            if partner_exists:
+                partner_vals = self._prepare_partner(vals)
+                if res.attendee_partner_id == self.env.user.partner_id:
+                    res.attendee_partner_id.sudo().write(partner_vals)
+
+                elif len(partner_vals) > 1:
+                    # If vals has more than email address
+                    # Add a note about posible problems with updating fields
+                    res.message_post("""
+                    Attendee partner record are not updated for security reasons:<br/> %s
+                    """ % partner_vals)
 
         return res
 

--- a/website_event_attendee_fields/tests/__init__.py
+++ b/website_event_attendee_fields/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_backend
+from . import test_security
 from . import test_workflow

--- a/website_event_attendee_fields/tests/test_backend.py
+++ b/website_event_attendee_fields/tests/test_backend.py
@@ -66,4 +66,3 @@ class TestBackend(common.TestCase):
         with self.assertRaises(AssertionError):
             obj = WebsiteEventControllerExtended()
             obj.registration_confirm(event, **post)
-

--- a/website_event_attendee_fields/tests/test_security.py
+++ b/website_event_attendee_fields/tests/test_security.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+
+from odoo import fields
+from odoo.tests.common import TransactionCase
+
+USER_DEMO = 'base.user_demo'
+
+
+class TestCase(TransactionCase):
+    at_install = True
+    post_install = True
+
+    def setUp(self):
+        super(TestCase, self).setUp()
+        self.event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'attendee_signup': True,
+            'create_partner': True,
+            'date_begin': fields.Datetime.to_string(datetime.today() + timedelta(days=1)),
+            'date_end': fields.Datetime.to_string(datetime.today() + timedelta(days=15)),
+        })
+
+    def test_self_registration(self):
+        """superuser creates registration for himself"""
+        agent = self.env.user.partner_id
+        NEW_NAME = 'New AdminName'
+
+        registration = self.env['event.registration'].create({
+            'partner_id': agent.id,
+            'event_id': self.event.id,
+            'name': NEW_NAME,
+            'email': agent.email,
+        })
+
+        self.assertEqual(
+            registration.partner_id.id,
+            agent.id,
+            "Wrong Agent value",
+        )
+        self.assertEqual(
+            registration.attendee_partner_id.id,
+            agent.id,
+            "Wrong Attendee value",
+        )
+
+        self.assertEqual(
+            registration.attendee_partner_id.name,
+            NEW_NAME,
+            "User has a right to change attendee values, if he buy ticket for himself",
+        )
+
+    def test_registration_for_existing_user(self):
+        """superuser creates registration for another user"""
+        agent = self.env.user.partner_id
+        NEW_NAME = 'New Demo Name'
+
+        attendee = self.env.ref(USER_DEMO)
+
+        registration = self.env['event.registration'].create({
+            'partner_id': agent.id,
+            'event_id': self.event.id,
+            'name': NEW_NAME,
+            'email': attendee.email,
+        })
+
+        self.assertNotEqual(
+            registration.attendee_partner_id.name,
+            NEW_NAME,
+            "Attendee's name must not be changed for security reasons",
+        )

--- a/website_event_attendee_signup/tests/common.py
+++ b/website_event_attendee_signup/tests/common.py
@@ -6,8 +6,6 @@ from odoo.tests.common import TransactionCase
 
 
 class TestCase(TransactionCase):
-    at_install = False
-    post_install = True
 
     def setUp(self):
         super(TestCase, self).setUp()

--- a/website_event_attendee_signup/tests/test_create.py
+++ b/website_event_attendee_signup/tests/test_create.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from . import common
 
+USER_DEMO = 'base.user_demo'
+
 
 class TestCreate(common.TestCase):
 
@@ -26,33 +28,4 @@ class TestCreate(common.TestCase):
         self.assertNotEqual(
             registration.attendee_partner_id,
             agent.id
-        )
-
-    def test_registration_for_existing_user(self):
-        """superuser creates registration for himself"""
-        agent = self.env.user.partner_id
-        NEW_NAME = 'New AdminName'
-
-        registration = self.env['event.registration'].create({
-            'partner_id': agent.id,
-            'event_id': self.event.id,
-            'name': NEW_NAME,
-            'email': agent.email,
-        })
-
-        self.assertEqual(
-            registration.partner_id.id,
-            agent.id,
-            "Wrong Agent value",
-        )
-        self.assertEqual(
-            registration.attendee_partner_id.id,
-            agent.id,
-            "Wrong Attendee value",
-        )
-
-        self.assertNotEqual(
-            registration.partner_id.name,
-            NEW_NAME,
-            "Contact's name must not be changed for security reasons",
         )


### PR DESCRIPTION
(i.e. when partner existed before creating registration)

It was removed previously in this commit
https://github.com/it-projects-llc/addons-dev/commit/bc93e264ad66f208e28dc8c5626f455f69f89913#diff-5051ffd02cd6505901f58b76e5b8a18fL41

with a comment:

> [REM] This commit also removes features "Updates contact's data at anyway" which
> is not safe (one can update information of existing user by simply knowing his email)

So, revert it and add a check, that current user is the same as attendee