### PR TITLE
[FIX] allow create registration for Event Manager

### DIFF
--- a/website_event_attendee_signup/models/event_registration.py
+++ b/website_event_attendee_signup/models/event_registration.py
@@ -15,6 +15,7 @@ class EventRegistration(models.Model):
                        .search([('login', '=ilike', login)])
             if not user:
                 user = self.env['res.users']\
+                           .sudo()\
                            ._signup_create_user({
                                'login': login,
                                'partner_id': res.attendee_partner_id.id,


### PR DESCRIPTION
which doesn't have Settings Admin rights


Error log:

File "/opt/odoo/addons/website_event_attendee_signup/models/event_registration.py", line 20, in create

'partner_id': res.attendee_partner_id.id,

File "/usr/lib/python2.7/dist-packages/odoo/addons/auth_signup/models/res_users.py", line 100, in _signup_create_user

raise SignupError(ustr(e))

SignupError: Sorry, you are not allowed to create this kind of document. Only users with the following access level are currently allowed to do that:

Administration/Access Rights