### PR TITLE
[FIX] All lines in registration form were autofilled

### DIFF
--- a/website_event_attendee_fields/__manifest__.py
+++ b/website_event_attendee_fields/__manifest__.py
@@ -5,7 +5,7 @@
     "category": "Marketing",
     # "live_test_url": "",
     "images": ['static/description/custom-fields-750.png'],
-    "version": "2.0.0",
+    "version": "10.0.2.0.0",
     "application": False,
 
     "author": "IT-Projects LLC, Ivan Yelizariev",

--- a/website_event_attendee_fields/static/src/js/test_tour.js
+++ b/website_event_attendee_fields/static/src/js/test_tour.js
@@ -30,6 +30,9 @@ odoo.define('website_event_attendee_fields.test_tour', function (require) {
             extra_trigger: "input[name='1-function']",
             trigger: "input[name='1-name']",
             run: function () {
+                if ($("input[name='2-email']").val()){
+                    console.log('error', 'Only first attendee can be autofilled');
+                }
                 $("input[name='1-name']").val("Att1");
                 $("input[name='1-phone']").val("111 111");
                 $("input[name='1-email']").val("att1@example.com");

--- a/website_event_attendee_fields/views/website_event_templates.xml
+++ b/website_event_attendee_fields/views/website_event_templates.xml
@@ -36,9 +36,7 @@
             <div class="message col-md-12"></div>
             <t t-set="attendee_placeholder">[Attendee #%s] </t>
             <t t-set="is_public_user" t-value="env.user == website.user_id"/>
-            <t t-if="not autofill_user">
-                <t t-set="autofill_user" t-value="counter==1 and not is_public_user and not event.is_participating and env.user"/>
-            </t>
+            <t t-set="autofill_user" t-value="counter==1 and (autofill_user or not is_public_user and not event.is_participating and env.user)"/>
             <t t-foreach="event.attendee_field_ids" t-as="field">
                 <t t-set="field_value" t-value="autofill_user and field.get_value(autofill_user.partner_id) or ''"/>
                 <div t-attf-class="col-md-{{field.width}} mb8 mt8">


### PR DESCRIPTION
it should be only first one. If user clicks continue instead of changing email
he gots Internal server error (constrain for not using multiple emails)

The issue was presented since https://github.com/it-projects-llc/addons-dev/pull/337

This update fix the issue and updates CI-tests